### PR TITLE
Change Homebrew curl url, added some npm globals

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -35,7 +35,7 @@ if [ -x "$(which brew)" ]; then
   echo Skipping brew
 else
   echo Installing brew
-  ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go/install)"
+  ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
 fi
 
 # Is MongoDB needed?
@@ -68,3 +68,5 @@ fi
 # Install a bunch of useful tools
 brew install wget mtr iftop pv tmux
 
+# Install some useful npm packages globally
+npm install -g jscs jshint pliers mocha


### PR DESCRIPTION
Homebrew no longer lives at [/mxcl/homebrew](https://github.com/mxcl/homebrew), it now lives at [/Homebrew/homebrew](https://github.com/Homebrew/homebrew). `curl` should handle this with `-L`, but on a fresh install of Mavericks `curl -fsSL https://raw.github.com/mxcl/homebrew/go/install` was returning `400: Bad request` for me, so probably worth changing just incase.

Also added some useful npm global packages that I had to install in my first week, including pliers.