### PR TITLE
Use correct url for script in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ Will give you:
 * ZeroMQ (Messaging System)
 
 ```sh
-curl -sSL https://raw.github.com/panfantastic/setup/master/setup.sh >/tmp/setup.sh
+curl -sSL https://raw.github.com/clocklimited/setup/master/setup.sh >/tmp/setup.sh
 bash /tmp/setup.sh
 ```


### PR DESCRIPTION
It was referencing a script that is not in this repo, so could do all manor of things!